### PR TITLE
Remove PropTypes as it has been deprecated

### DIFF
--- a/src/components/AddTodo.jsx
+++ b/src/components/AddTodo.jsx
@@ -1,7 +1,6 @@
 import { memo } from "react";
 import { useFormik } from "formik";
 import Button from "@mui/material/Button";
-import PropTypes from "prop-types";
 import Stack from "@mui/material/Stack";
 import TextField from "@mui/material/TextField";
 
@@ -56,10 +55,6 @@ const AddTodo = ({ addTodo }) => {
       </Stack>
     </form>
   );
-};
-
-AddTodo.propTypes = {
-  addTodo: PropTypes.func.isRequired,
 };
 
 export default memo(AddTodo);

--- a/src/components/Todo.jsx
+++ b/src/components/Todo.jsx
@@ -3,7 +3,6 @@ import DeleteIcon from "@mui/icons-material/Delete";
 import SaveIcon from "@mui/icons-material/Save";
 import IconButton from "@mui/material/IconButton";
 import TextField from "@mui/material/TextField";
-import PropTypes from "prop-types";
 import { useFormik } from "formik";
 
 import { useAuth } from "../hooks/useAuth";
@@ -58,16 +57,6 @@ const Todo = ({ todo, updateTodo, deleteTodo }) => {
       </IconButton>
     </form>
   );
-};
-
-Todo.propTypes = {
-  todo: PropTypes.shape({
-    id: PropTypes.number.isRequired,
-    task: PropTypes.string.isRequired,
-    user_id: PropTypes.string,
-  }).isRequired,
-  updateTodo: PropTypes.func.isRequired,
-  deleteTodo: PropTypes.func.isRequired,
 };
 
 export default memo(Todo);

--- a/src/containers/AccountForm.jsx
+++ b/src/containers/AccountForm.jsx
@@ -2,7 +2,6 @@ import { memo } from "react";
 import { useFormik } from "formik";
 import * as yup from "yup";
 import Button from "@mui/material/Button";
-import PropTypes from "prop-types";
 import TextField from "@mui/material/TextField";
 
 const validationSchema = yup.object({
@@ -73,10 +72,6 @@ const AccountForm = ({ onSubmit }) => {
       </Button>
     </form>
   );
-};
-
-AccountForm.propTypes = {
-  onSubmit: PropTypes.func.isRequired,
 };
 
 export default memo(AccountForm);

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -1,5 +1,4 @@
 import { useEffect, useState, memo } from "react";
-import PropTypes from "prop-types";
 
 import { AuthContext } from "../hooks/useAuth";
 import supabase from "../utils/supabase";
@@ -49,9 +48,5 @@ const AuthProvider = memo((props) => {
     <AuthContext.Provider value={value}>{props.children}</AuthContext.Provider>
   );
 });
-
-AuthProvider.propTypes = {
-  children: PropTypes.node.isRequired,
-};
 
 export default AuthProvider;


### PR DESCRIPTION
Fixes #17

Remove all instances of `PropTypes` from the codebase.

* **src/components/AddTodo.jsx**
  - Remove the import statement for `PropTypes`.
  - Remove the `AddTodo.propTypes` definition.

* **src/components/Todo.jsx**
  - Remove the import statement for `PropTypes`.
  - Remove the `Todo.propTypes` definition.

* **src/containers/AccountForm.jsx**
  - Remove the import statement for `PropTypes`.
  - Remove the `AccountForm.propTypes` definition.

* **src/context/AuthContext.jsx**
  - Remove the import statement for `PropTypes`.
  - Remove the `AuthProvider.propTypes` definition.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/juancarlosjr97/react-vite-supabase-vercel/pull/18?shareId=c1ed1588-0f90-4042-83ca-34cdec7db456).