### PR TITLE
Add test for logos 

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -25,7 +25,7 @@ function App() {
           />
         </a>
         <a href="https://vercel.com/" target="_blank">
-          <img src={vercelLogo} className="logo vercel" alt="React Supabase" />
+          <img src={vercelLogo} className="logo vercel" alt="React Vercel" />
         </a>
         <p className="read-the-docs">Click on logos to learn more.</p>
       </div>

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -1,16 +1,24 @@
 import { expect, test } from "vitest";
 import { render } from "vitest-browser-react";
-
 import App from "./App";
 
 test("renders name", async () => {
-  const { getByText } = render(<App />);
+  const { getByText, getByAltText } = render(<App />);
 
   const headingTitle = "React + Vite + Supabase + Vercel";
-
   const headingElement = getByText(headingTitle);
 
   await expect.element(headingElement).toBeInTheDocument();
-
   expect(headingElement.element().innerHTML).toBe(headingTitle);
+
+  // Check if logos are rendered correctly
+  const reactLogo = getByAltText("React logo");
+  const viteLogo = getByAltText("Vite logo");
+  const supabaseLogo = getByAltText("React Supabase");
+  const vercelLogo = getByAltText("React Vercel");
+
+  await expect.element(reactLogo).toBeInTheDocument();
+  await expect.element(viteLogo).toBeInTheDocument();
+  await expect.element(supabaseLogo).toBeInTheDocument();
+  await expect.element(vercelLogo).toBeInTheDocument();
 });


### PR DESCRIPTION
This pull request includes updates to the `App` component and its corresponding test file to fix an alt text and enhance test coverage.

Alt text correction:

* [`src/App.jsx`](diffhunk://#diff-d274a54187c91ba0f532df2a9e194e27ab50e988f5e4c33f5a7893918320c661L28-R28): Corrected the alt text for the Vercel logo from "React Supabase" to "React Vercel".

Test coverage enhancement:

* [`src/App.test.jsx`](diffhunk://#diff-c25eab590d709c5a7a54c09373052848c1c5e1e619f6a02e3e435bc6919edcb8L3-R23): Added assertions to check if the logos for React, Vite, Supabase, and Vercel are rendered correctly.